### PR TITLE
More resilient handling when template message is added without locale file changes

### DIFF
--- a/lib/closure-translater.js
+++ b/lib/closure-translater.js
@@ -15,12 +15,6 @@ var _ = require('underscore'),
 	ClosureTranslater,
 	localeDataPromises;
 
-if (!String.prototype.endsWith) {
-	String.prototype.endsWith = function (suffix) {
-		return this.indexOf(suffix, this.length - suffix.length) !== -1;
-	};
-}
-
 /**
  * Returns the specified string as an `'`-enclosed string suitable for printing to JS
  */
@@ -143,6 +137,14 @@ function buildI18n(fileContents, translations, defaultLocale, replacementRegex) 
 			currentMessageCall.definition += line + '\n';
 		}
 
+		/**
+		 * Return whether the given argument is a literal
+		 * @param {object} argumentAST an argument object from a CallExpression AST
+		 */
+		function argumentIsLiteral(argumentAST) {
+			return (argumentAST.type === 'Literal');
+		}
+
 		// Are we continuing a message definition?
 		if (currentMessageCall) {
 			try {
@@ -159,10 +161,21 @@ function buildI18n(fileContents, translations, defaultLocale, replacementRegex) 
 						target,
 						translatedMessage;
 
-					if (!msgTranslation) {
+					if (!msgTranslation && translations[defaultLocale][messageID]) {
 						// Message not present in translation file -- fall back to default locale's message
 						msgTranslation = translations[defaultLocale][messageID];
-						if (!msgTranslation) {
+					} else if (!msgTranslation) {
+
+						// Locale file changes must've not been committed - attempt to use the arguments to goog.getMsg()
+						// as the translation string (but only if they're literal).
+						if ((definitionAST.body[0].expression.type === 'CallExpression') &&
+								_.every(definitionAST.body[0].expression.arguments, argumentIsLiteral)) {
+							msgTranslation = {
+								target: definitionAST.body[0].expression.arguments.map(function (arg) {
+									return arg.value;
+								})
+							};
+						} else {
 							throw new Error('Failed to find translation for message ID: ' + messageID);
 						}
 					}
@@ -175,7 +188,7 @@ function buildI18n(fileContents, translations, defaultLocale, replacementRegex) 
 
 					// Someone's trying to translate an empty string. Why? Who knows, warn about it but proceed...
 					if (!target.length) {
-						console.warn('Translation not found for message ID:', messageID);
+						console.warn('Empty translation for message ID:', messageID);
 						target = [''];
 					}
 


### PR DESCRIPTION
### What does this PR do? How does it affect users?

This fixes a particular case of failure in the Webpack build, seen here: https://jenkins.kinja-ops.com/jenkins/job/kinja-mantle-grunt-webpack-testing/56/console .  When templates are changed to add a new message, but matching locale file updates aren't committed, currently the build fails.  This makes the build more resilient to this type of issue by successfully translating as long as the translation string was a simple literal.

### How should this be tested (feature switches, URLs, special user permissions)?

Note that build via e.g. `grunt devbuild-webpack` succeeds, including in Mantle master @ 3bef4c0602b20b6723d1167b6145fbad5588cb86.

### Related Trello card, wiki page or blog posts

https://trello.com/c/L6vCOvQH/5-switch-to-webpack-as-build-tool-in-place-of-require-use-inline-script-tags