### PR TITLE
Add unit tests for Closure Translater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "4.1"
+  - "4.0"
+  - "stable"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,11 @@
     "underscore": "^1.8.3",
     "underscore.string": "^3.2.2",
     "webpack": "^1.12.2"
+  },
+  "devDependencies": {
+    "mocha": "^2.3.3"
+  },
+  "scripts": {
+	"test": "mocha test"
   }
 }

--- a/test/closure-translater.js
+++ b/test/closure-translater.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/* jshint node:true*/
+/*global __dirname, describe, it, before, require*/
+
+var assert = require('assert');
+var ClosureTranslater = require('../lib/closure-translater');
+var fs = require('fs');
+var path = require('path');
+
+var fixturePath = path.join(__dirname, 'fixtures/');
+
+function readFixture(name) {
+	return fs.readFileSync(path.join(fixturePath, name), {'encoding': 'utf8'});
+}
+
+describe('ClosureTranslater', function() {
+
+	var translater;
+
+	before(function (done) {
+		translater = new ClosureTranslater({
+			localeFiles: {
+				'en-US': path.join(fixturePath, 'en-US.xlf'),
+				'es-ES': path.join(fixturePath, 'es-ES.xlf')
+			},
+			defaultLocale: 'en-US',
+			replacementString: '[FAST_LOCALE]'
+		});
+		translater.messagesLoaded.then(done.bind(null, null));
+	});
+
+	it('should translate simple string as expected', function () {
+		var translations = translater.translate(readFixture('literal.js'));
+		assert.equal(translations['es-ES'], '// Simple literal string\n' + 'var MSG_EXTERNAL_9133897793175013620 = \'Aún guardando...\';\n\n');
+	});
+
+	it('should translate message with links as expected', function () {
+		var translations = translater.translate(readFixture('link.js')),
+			expected = '// Links\n\n\n\n' +
+				'var MSG_EXTERNAL_9138152196605060651 = \'Acepto los \' + \'<a href="http://legal.kinja.com/kinja-terms-of-use-90161644"' +
+				' target="_blank" class="primary-color">\' + \'Términos de Uso\' + \'</a>\'' +
+				' + \'.\';' + '\n\n';
+		assert.equal(translations['es-ES'], expected);
+	});
+
+	it('should translate message with variables as expected', function () {
+		var translations = translater.translate(readFixture('variables.js'));
+		assert.equal(translations['es-ES'], '// Variables' + '\n\n\n\n' + 
+			'var MSG_EXTERNAL_8973741402914534427 = \'Aprobar \' + soy.$$escapeHtml(opt_data.post.authorBlogName) + \' en \' + ' +
+			'soy.$$escapeHtml(blogDisplayName__soy6692);\n\n');
+	});
+
+	it('should gracefully handle simple string with missing translations', function () {
+		var translations = translater.translate(readFixture('literal-with-missing-locale-file-message.js')),
+			expected = '// Simple literal string, with definition missing from locale files\n' +
+					'var MSG_EXTERNAL_9133797763175013623 = \'One hundred million dollars.\';\n\n';
+		assert.equal(translations['es-ES'], expected);
+	});
+});
+

--- a/test/fixtures/en-US.xlf
+++ b/test/fixtures/en-US.xlf
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="SoyMsgBundle" datatype="x-soy-msg-bundle" xml:space="preserve" source-language="en" target-language="en-US">
+    <body>
+      <trans-unit datatype="html" id="8973741402914534427">
+        <source>Approve <x id="AUTHOR_BLOG_NAME"/> on <x id="BLOG_DISPLAY_NAME"/></source>
+        <target></target>
+        <note priority="1" from="description">Button Label - Approve user for blog</note>
+      </trans-unit>
+      <trans-unit datatype="html" id="9133897793175013620">
+        <source>Still Saving...</source>
+        <target>Still Saving...</target>
+        <note priority="1" from="description">Editor - saving post</note>
+      </trans-unit>
+      <trans-unit datatype="html" id="9138152196605060651">
+        <source>I accept the <x id="START_LINK_1"/>Terms of Use<x id="END_LINK"/>.</source>
+		<target>I accept the <x id="START_LINK_1"/>Terms of Use<x id="END_LINK"/>.</target>
+        <note priority="1" from="description">Login Info - I have read, understand, and agree to the Terms of Service.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/test/fixtures/es-ES.xlf
+++ b/test/fixtures/es-ES.xlf
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="SoyMsgBundle" datatype="x-soy-msg-bundle" xml:space="preserve" source-language="en" target-language="es-ES">
+    <body>
+      <trans-unit datatype="html" id="8973741402914534427">
+        <source>Aprobar <x id="AUTHOR_BLOG_NAME"/> en <x id="BLOG_DISPLAY_NAME"/></source>
+        <target></target>
+        <note priority="1" from="description">Button Label - Approve user for blog</note>
+      </trans-unit>
+      <trans-unit datatype="html" id="9133897793175013620">
+        <source>Still Saving...</source>
+        <target>Aún guardando...</target>
+        <note priority="1" from="description">Editor - saving post</note>
+      </trans-unit>
+      <trans-unit datatype="html" id="9138152196605060651">
+        <source>I accept the <x id="START_LINK_1"/>Terms of Use<x id="END_LINK"/>.</source>
+        <target>Acepto los <x id="START_LINK_1"/>Términos de Uso<x id="END_LINK"/>.</target>
+        <note priority="1" from="description">Login Info - I have read, understand, and agree to the Terms of Service.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/test/fixtures/link.js
+++ b/test/fixtures/link.js
@@ -1,0 +1,5 @@
+// Links
+var MSG_EXTERNAL_9138152196605060651 = goog.getMsg(
+  'I accept the {$startLink_1}Terms of Use{$endLink}.',
+  {'startLink_1': '<a href="http://legal.kinja.com/kinja-terms-of-use-90161644" target="_blank" class="primary-color">',
+   'endLink': '</a>'});

--- a/test/fixtures/literal-with-missing-locale-file-message.js
+++ b/test/fixtures/literal-with-missing-locale-file-message.js
@@ -1,0 +1,2 @@
+// Simple literal string, with definition missing from locale files
+var MSG_EXTERNAL_9133797763175013623 = goog.getMsg('One hundred million dollars.');

--- a/test/fixtures/literal.js
+++ b/test/fixtures/literal.js
@@ -1,0 +1,2 @@
+// Simple literal string
+var MSG_EXTERNAL_9133897793175013620 = goog.getMsg('Still Saving...');

--- a/test/fixtures/variables.js
+++ b/test/fixtures/variables.js
@@ -1,0 +1,5 @@
+// Variables
+var MSG_EXTERNAL_8973741402914534427 = goog.getMsg(
+	'Approve {$authorBlogName} on {$blogDisplayName}',
+	{'authorBlogName': soy.$$escapeHtml(opt_data.post.authorBlogName),
+	 'blogDisplayName': soy.$$escapeHtml(blogDisplayName__soy6692)});


### PR DESCRIPTION
### What does this PR do? How does it affect users?

This adds basic unit tests (using Mocha) for the Closure Translater library that is used by our Webpack Closure i18n plugin to translate Closure Template messages.  This is the most substantial and potentially bug-prone component involved in the translation plugin; most everything else is glue code.

### How should this be tested (feature switches, URLs, special user permissions)?

Observe test successes in https://travis-ci.org/gawkermedia/webpack-closure-i18n/builds/89665999

### Related Trello card, wiki page or blog posts

https://trello.com/c/Febvu772/80-add-unit-tests-for-webpack-closure-translation-plugin